### PR TITLE
fixing ACCOUNT_ID and AWS_REGION variables in preparation

### DIFF
--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -1,13 +1,13 @@
 version: 1.0
-runtime: python3 
+runtime: python3
 build:
   commands:
-    build:        
+    build:
       - pip install -r requirements.txt
 run:
-  command: python app.py  
-  network: 
+  command: python app.py
+  network:
     port: 8080
   env:
     - name: DDB_AWS_REGION
-      value: "us-east-1" 
+      value: "eu-west-1"

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -10,4 +10,4 @@ run:
     port: 8080
   env:
     - name: DDB_AWS_REGION
-      value: "eu-west-1"
+      value: "us-east-1"

--- a/preparation/README.md
+++ b/preparation/README.md
@@ -1,3 +1,3 @@
-The `prepare.sh` script creates the DDB table and create an IAM role with a policy to access it. You can associate this role to an Amazon App Runner service (the role is federated with Amazon App Runner). 
+The `prepare.sh` script creates the DDB table and create an IAM role with a policy to access it. You can associate this role to an Amazon App Runner service (the role is federated with Amazon App Runner).
 
-The script assign a DDB table name and IAM role name in two variables at the beginning. You can change them if you wish. Note you need to export the `AWS_REGION` variable before running the script. 
+The script assign a DDB table name and IAM role name in two variables at the beginning. You can change them if you wish.

--- a/preparation/prepare.sh
+++ b/preparation/prepare.sh
@@ -2,7 +2,8 @@
 
 export TABLE_NAME="votingapp-restaurants"
 export IAM_ROLE="votingapp-role"
-export ACCOUNT_ID=$(aws sts get-caller-identity | jq -r .Account) 
+export ACCOUNT_ID=$(aws sts get-caller-identity --output text --query 'Account') 
+export AWS_REGION=$(aws configure get region)
 if [ -z ${AWS_REGION} ]; then echo "you need to export the AWS_REGION variable"; exit; fi
 
 aws dynamodb create-table \


### PR DESCRIPTION
- Leveraging `--output` and `--query` we can avoid the jq requirement. 
- We can get the region from awscli in preparation reading the configuration to make it quicker! : ) 