### PR TITLE
Update Dockerfile to use Python3.8 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/python:3.6-prod
+FROM public.ecr.aws/bitnami/python:3.8-prod
 
 COPY . /app
 


### PR DESCRIPTION
The recent change to `Werkzeug==2.2.2` caused the docker image build to fail. Using `public.ecr.aws/bitnami/python:3.8-prod` as base seems to cure this problem.